### PR TITLE
Add support for multiple translations

### DIFF
--- a/locale/it.yml
+++ b/locale/it.yml
@@ -1,0 +1,17 @@
+core:
+  forum:
+    index_sort:
+      popular_button: Popolari
+      unpopular_button: Impopolari
+
+flarum_discussion_views:
+  forum:
+    modal_resetviews:
+      title: Modifica visualizzazioni
+      submit: Imposta
+      label: Imposta visualizzazioni
+    discussion_controls:
+      resetviews_button: Imposta visualizzazioni
+  admin:
+      permissions:
+          reset_views_label: Imposta il numero di visualizzazioni

--- a/src/listeners/AddAssets.php
+++ b/src/listeners/AddAssets.php
@@ -2,6 +2,7 @@
 
 namespace michaelbelgium\views\listeners;
 
+use DirectoryIterator;
 use Flarum\Event\ConfigureWebApp;
 use Flarum\Event\ConfigureLocales;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -45,6 +46,10 @@ class AddAssets
      */
     public function configLocales(ConfigureLocales $event)
     {
-        $event->locales->addTranslations('en', __DIR__.'/../../locale/en.yml');
+        foreach (new DirectoryIterator(__DIR__.'/../../locale') as $file) {
+            if ($file->isFile() && in_array($file->getExtension(), ['yml', 'yaml'], false)) {
+                $event->locales->addTranslations($file->getBasename('.'.$file->getExtension()), $file->getPathname());
+            }
+        }
     }
 }


### PR DESCRIPTION
Right now the english translation in the only one loaded and allowed by the extension.
This patch adds support for all the translation in the locale folder, as most extensions already do.