### PR TITLE
Remove first char being uppercase

### DIFF
--- a/js/src/forum/components/AddViewsToModelAndDisplay.js
+++ b/js/src/forum/components/AddViewsToModelAndDisplay.js
@@ -39,7 +39,7 @@ export default function () {
         const viewList = new ItemList();
 
         $.each(views, function(key, view) {
-            var userName = view.user() === false ? 'Guest' : ucfirst(view.user().username());
+            var userName = view.user() === false ? 'Guest' : view.user().username();
 
             var listitem = 
                 <div className="item-lastUser-content">


### PR DESCRIPTION
Closes #26 

If users set their name as all lowercase, it should respect that. Optionally a config option could be used to configure this but for consistency the username should be the same everywhere.