### PR TITLE
Fix naming issue on permissions resetViews and readViewnumber

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -53,11 +53,11 @@ return [
 
     (new ApiSerializer(DiscussionSerializer::class))
         ->attribute('canReset', function (DiscussionSerializer $serializer, $discussion) {
-            return (bool)$serializer->getActor()->can('discussion.resetViews', $discussion);
+            return (bool)$serializer->getActor()->can('resetViews', $discussion);
         })->attribute('viewCount', function (DiscussionSerializer $serializer, $discussion) {
             return $discussion->view_count;
         })->attribute('canViewNumber', function (DiscussionSerializer $serializer, $discussion) {
-            return (bool)$serializer->getActor()->can('discussion.readViewnumber', $discussion);
+            return (bool)$serializer->getActor()->can('readViewnumber', $discussion);
         })->hasMany(DV_RELATIONSHIP_LATEST, DiscussionViewSerializer::class)
         ->hasMany(DV_RELATIONSHIP_UNIQUE, DiscussionViewSerializer::class),
 


### PR DESCRIPTION
The permissions readViewnumber and resetViews are not working correctly for the user groups _all_ and _members_.

The permissions are not checked correctly, as the discussion policy (flarum/tags/src/Access/DiscussionPolicy.php) already puts _discussion._ on the permission string and thus looking for fx. '_tag1.discussion.discussion.readViewnumber_' where the user has '_tag1.discussion.readViewnumber_'.

Removing discussion. from the permission string fixes this issue.

![image](https://user-images.githubusercontent.com/22655862/142212554-3727618a-f1b7-47f0-bc96-812bb9ec20ca.png)
![image](https://user-images.githubusercontent.com/22655862/142212648-96b1eaa3-12b3-4a3b-b85f-d950a6f29ee8.png)

![image](https://user-images.githubusercontent.com/22655862/142212815-4b53d31d-b14d-4d91-805f-0110d6aad217.png)
![image](https://user-images.githubusercontent.com/22655862/142212882-3d4ea1ea-6267-4ad7-b1a2-9172cb1c3b6b.png)
