### PR TITLE
[BUGFIX] Fix permission checks for access restricted tags

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -53,11 +53,11 @@ return [
 
     (new ApiSerializer(DiscussionSerializer::class))
         ->attribute('canReset', function (DiscussionSerializer $serializer, $discussion) {
-            return (bool)$serializer->getActor()->can('discussion.resetViews', $discussion);
+            return (bool)$serializer->getActor()->can('resetViews', $discussion);
         })->attribute('viewCount', function (DiscussionSerializer $serializer, $discussion) {
             return $discussion->view_count;
         })->attribute('canViewNumber', function (DiscussionSerializer $serializer, $discussion) {
-            return (bool)$serializer->getActor()->can('discussion.readViewnumber', $discussion);
+            return (bool)$serializer->getActor()->can('readViewnumber', $discussion);
         })->hasMany(DV_RELATIONSHIP_LATEST, DiscussionViewSerializer::class)
         ->hasMany(DV_RELATIONSHIP_UNIQUE, DiscussionViewSerializer::class),
 


### PR DESCRIPTION
Permission checks for access restricted tags for the policy `readViewnumber` and `resetViews` does currently not work (e.g. no read view count is shown), because the permission check uses `discussion.readViewnumber` instead of `readViewnumber`. For tags, which are not access restricted this is no problem, because the final access check in `Flarum\User\Access\Gate::allows()` will allow `discussion.readViewnumber` in `$actor->hasPermission($ability)`.

In order to resolve the problem, the `discussion.` string has to be removed, since this is appended by `flarum/tags` Access policy checks.