### PR TITLE
Add migration to increase IP column size for IPv6 support

### DIFF
--- a/js/src/forum/components/AddLists.ts
+++ b/js/src/forum/components/AddLists.ts
@@ -26,7 +26,7 @@ export default function () {
           ? app.translator.trans(
               "michaelbelgium-discussion-views.forum.viewlist.guest",
             )
-          : view.user().username();
+          : view.user().displayName();
 
       let listitem = m("div", { className: "item-lastUser-content" }, [
         avatar(<User>view.user()),
@@ -90,7 +90,7 @@ export default function () {
               ? app.translator.trans(
                   "michaelbelgium-discussion-views.forum.post.you",
                 )
-              : username(view.user()),
+              : view.user().displayName(),
           ),
         );
 

--- a/migrations/2025_10_06_000000_alter_discussion_views_ip_column.php
+++ b/migrations/2025_10_06_000000_alter_discussion_views_ip_column.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('discussion_views', function (Blueprint $table) {
+            // A varchar length of 45 is recommended for IPv6 addresses.
+            $table->string('ip', 45)->change();
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('discussion_views', function (Blueprint $table) {
+            $table->string('ip', 16)->change();
+        });
+    }
+];


### PR DESCRIPTION
Fix: Add migration for IPv6 supportFixes #issue-number 47
[Bug: Unique view tracking fails for IPv6 addresses due to database column size Issue Body](https://github.com/MichaelBelgium/flarum-discussion-views/issues/47)