### PR TITLE
Performance optimization for >10M views

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ php flarum migrate
 php flarum cache:clear
 ```
 
+# View record archiving
+
+The extension keeps the latest 1000 detailed view records for each discussion. Older records are counted in `discussion_view_archives`, while the total shown by Flarum remains in `discussions.view_count`.
+
+Archiving is registered with Flarum's scheduler and runs every ten minutes. Make sure the standard Flarum scheduler cron is configured, or run the command manually:
+
+```
+php flarum discussion-views:archive
+```
+
+The `discussion_view_uniques` table only stores indexed discussion/IP pairs. It is required to preserve all-time unique-view tracking after detailed records have been archived.
+
 # Translations
 If you would like to translate this extension to your language, make a PR in the corresponding language pack. 
 

--- a/extend.php
+++ b/extend.php
@@ -9,6 +9,7 @@ use Flarum\Discussion\Event\Saving;
 use Flarum\Extend\ApiController;
 use Flarum\Extend\ApiSerializer;
 use Flarum\Extend\Conditional;
+use Flarum\Extend\Console;
 use Flarum\Extend\Event;
 use FoF\MergeDiscussions\Events\MergingDiscussions;
 use Michaelbelgium\Discussionviews\Listeners;
@@ -19,6 +20,8 @@ use Flarum\Extend\Settings;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Michaelbelgium\Discussionviews\Models\DiscussionView;
 use Michaelbelgium\Discussionviews\Serializers\DiscussionViewSerializer;
+use Michaelbelgium\Discussionviews\Console\ArchiveDiscussionViewsCommand;
+use Illuminate\Console\Scheduling\Event as ScheduledEvent;
 
 $settings = resolve(SettingsRepositoryInterface::class);
 
@@ -38,7 +41,7 @@ return [
 
     (new Model(Discussion::class))
         ->relationship(DV_RELATIONSHIP, function (AbstractModel $model) {
-            return $model->hasMany(DiscussionView::class)->orderBy('visited_at', 'DESC');
+            return $model->hasMany(DiscussionView::class)->orderBy('visited_at', 'DESC')->orderBy('id', 'DESC');
         })->relationship(DV_RELATIONSHIP_LATEST, function (AbstractModel $model) use ($settings) {
             return $model->views()->limit($settings->get('michaelbelgium-discussionviews.max_listcount', 5));
         })->relationship(DV_RELATIONSHIP_UNIQUE, function (AbstractModel $model) use ($settings) {
@@ -79,6 +82,12 @@ return [
 
     (new ApiController(ListDiscussionsController::class))
         ->addSortField('view_count'),
+
+    (new Console())
+        ->command(ArchiveDiscussionViewsCommand::class)
+        ->schedule(ArchiveDiscussionViewsCommand::class, function (ScheduledEvent $event) {
+            $event->everyTenMinutes()->withoutOverlapping(30)->onOneServer();
+        }),
 
     (new Event())
         ->listen(Saving::class, Listeners\SaveDiscussionFromModal::class),

--- a/js/src/forum/components/AddLists.ts
+++ b/js/src/forum/components/AddLists.ts
@@ -66,6 +66,7 @@ export default function () {
         },
         viewList.toArray(),
       ),
+      -999,
     );
   });
 

--- a/migrations/2026_07_14_000000_add_discussion_view_archiving.php
+++ b/migrations/2026_07_14_000000_add_discussion_view_archiving.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->create('discussion_view_archives', function (Blueprint $table) {
+            $table->unsignedInteger('discussion_id')->primary();
+            $table->unsignedBigInteger('archived_view_count')->default(0);
+
+            $table->foreign('discussion_id')->references('id')->on('discussions')->onDelete('CASCADE')->onUpdate('CASCADE');
+        });
+
+        // This registry preserves all-time IP uniqueness without retaining old visit details.
+        $schema->create('discussion_view_uniques', function (Blueprint $table) {
+            $table->unsignedInteger('discussion_id');
+            $table->string('ip', 45);
+
+            $table->primary(['discussion_id', 'ip']);
+            $table->foreign('discussion_id')->references('id')->on('discussions')->onDelete('CASCADE')->onUpdate('CASCADE');
+        });
+
+        $schema->table('discussion_views', function (Blueprint $table) {
+            $table->index(['discussion_id', 'visited_at', 'id'], 'discussion_views_retention_index');
+            $table->index(['discussion_id', 'ip'], 'discussion_views_ip_index');
+            $table->index(['discussion_id', 'user_id', 'visited_at'], 'discussion_views_user_visited_index');
+        });
+
+        $schema->table('discussions', function (Blueprint $table) {
+            $table->index('view_count', 'discussions_view_count_index');
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('discussions', function (Blueprint $table) {
+            $table->dropIndex('discussions_view_count_index');
+        });
+
+        $schema->table('discussion_views', function (Blueprint $table) {
+            $table->dropIndex('discussion_views_retention_index');
+            $table->dropIndex('discussion_views_ip_index');
+            $table->dropIndex('discussion_views_user_visited_index');
+        });
+
+        $schema->dropIfExists('discussion_view_uniques');
+        $schema->dropIfExists('discussion_view_archives');
+    }
+];

--- a/src/Archive/DiscussionViewArchiver.php
+++ b/src/Archive/DiscussionViewArchiver.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Michaelbelgium\Discussionviews\Archive;
+
+use Illuminate\Database\ConnectionInterface;
+
+class DiscussionViewArchiver
+{
+    public const RETAINED_VIEWS = 1000;
+
+    private const DELETE_BATCH_SIZE = 5000;
+    private const DISCUSSION_PAGE_SIZE = 500;
+
+    private ConnectionInterface $database;
+
+    public function __construct(ConnectionInterface $database)
+    {
+        $this->database = $database;
+    }
+
+    /**
+     * @return array{discussions: int, views: int}
+     */
+    public function archive(): array
+    {
+        $archivedDiscussions = 0;
+        $archivedViews = 0;
+        $lastDiscussionId = 0;
+
+        do {
+            $discussionIds = $this->candidateDiscussionIdsAfter($lastDiscussionId);
+
+            foreach ($discussionIds as $discussionId) {
+                $lastDiscussionId = (int) $discussionId;
+                $deleted = $this->archiveDiscussion($lastDiscussionId);
+
+                if ($deleted > 0) {
+                    $archivedDiscussions++;
+                    $archivedViews += $deleted;
+                }
+            }
+        } while ($discussionIds->isNotEmpty());
+
+        return [
+            'discussions' => $archivedDiscussions,
+            'views' => $archivedViews,
+        ];
+    }
+
+    private function candidateDiscussionIdsAfter(int $discussionId)
+    {
+        return $this->database->table('discussions')
+            ->leftJoin('discussion_view_archives', 'discussion_view_archives.discussion_id', '=', 'discussions.id')
+            ->where('discussions.id', '>', $discussionId)
+            ->whereRaw(
+                'discussions.view_count > COALESCE(discussion_view_archives.archived_view_count, 0) + ?',
+                [self::RETAINED_VIEWS]
+            )
+            ->orderBy('discussions.id')
+            ->limit(self::DISCUSSION_PAGE_SIZE)
+            ->pluck('discussions.id');
+    }
+
+    private function archiveDiscussion(int $discussionId): int
+    {
+        $deletedTotal = 0;
+
+        do {
+            $deleted = $this->archiveBatch($discussionId);
+            $deletedTotal += $deleted;
+        } while ($deleted > 0);
+
+        return $deletedTotal;
+    }
+
+    private function archiveBatch(int $discussionId): int
+    {
+        return $this->database->transaction(function () use ($discussionId) {
+            $this->database->table('discussion_view_archives')->insertOrIgnore([
+                'discussion_id' => $discussionId,
+                'archived_view_count' => 0,
+            ]);
+
+            // Serializes manual and scheduled archivers for the same discussion.
+            $this->database->table('discussion_view_archives')
+                ->where('discussion_id', $discussionId)
+                ->lockForUpdate()
+                ->first();
+
+            $discussion = $this->database->table('discussions')
+                ->where('id', $discussionId)
+                ->lockForUpdate()
+                ->first(['view_count']);
+
+            if ($discussion === null) {
+                return 0;
+            }
+
+            $views = $this->database->table('discussion_views')
+                ->where('discussion_id', $discussionId)
+                ->orderByDesc('visited_at')
+                ->orderByDesc('id')
+                ->offset(self::RETAINED_VIEWS)
+                ->limit(self::DELETE_BATCH_SIZE)
+                ->get(['id', 'ip']);
+
+            if ($views->isEmpty()) {
+                $retainedViewCount = $this->database->table('discussion_views')
+                    ->where('discussion_id', $discussionId)
+                    ->count();
+
+                $this->database->table('discussion_view_archives')
+                    ->where('discussion_id', $discussionId)
+                    ->update([
+                        'archived_view_count' => max(0, (int) $discussion->view_count - $retainedViewCount),
+                    ]);
+
+                return 0;
+            }
+
+            $uniqueIps = $views
+                ->pluck('ip')
+                ->filter()
+                ->unique()
+                ->map(function ($ip) use ($discussionId) {
+                    return [
+                        'discussion_id' => $discussionId,
+                        'ip' => $ip,
+                    ];
+                })
+                ->values()
+                ->all();
+
+            if (! empty($uniqueIps)) {
+                $this->database->table('discussion_view_uniques')->insertOrIgnore($uniqueIps);
+            }
+
+            $deleted = $this->database->table('discussion_views')
+                ->whereIn('id', $views->pluck('id')->all())
+                ->where('discussion_id', $discussionId)
+                ->delete();
+
+            if ($deleted > 0) {
+                $this->database->table('discussion_view_archives')
+                    ->where('discussion_id', $discussionId)
+                    ->increment('archived_view_count', $deleted);
+            }
+
+            return $deleted;
+        });
+    }
+}

--- a/src/Console/ArchiveDiscussionViewsCommand.php
+++ b/src/Console/ArchiveDiscussionViewsCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Michaelbelgium\Discussionviews\Console;
+
+use Flarum\Console\AbstractCommand;
+use Michaelbelgium\Discussionviews\Archive\DiscussionViewArchiver;
+
+class ArchiveDiscussionViewsCommand extends AbstractCommand
+{
+    private DiscussionViewArchiver $archiver;
+
+    public function __construct(DiscussionViewArchiver $archiver)
+    {
+        parent::__construct();
+
+        $this->archiver = $archiver;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('discussion-views:archive')
+            ->setDescription('Archive old discussion view records');
+    }
+
+    protected function fire()
+    {
+        $result = $this->archiver->archive();
+
+        $this->info(sprintf(
+            'Archived %d view records from %d discussions.',
+            $result['views'],
+            $result['discussions']
+        ));
+    }
+}

--- a/src/Listeners/AddDiscussionViewHandler.php
+++ b/src/Listeners/AddDiscussionViewHandler.php
@@ -8,6 +8,7 @@ use Flarum\Discussion\Discussion;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Arr;
 use Jaybizzle\CrawlerDetect\CrawlerDetect;
 use Michaelbelgium\Discussionviews\Events\DiscussionWasViewed;
@@ -21,17 +22,20 @@ class AddDiscussionViewHandler
     private ExtensionManager $extensionManager;
     private Dispatcher $events;
     private SettingsRepositoryInterface $settings;
+    private ConnectionInterface $database;
 
     public function __construct(
         SettingsRepositoryInterface $settings,
         Dispatcher $events,
         ExtensionManager $extensionManager,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        ConnectionInterface $database
     ) {
         $this->settings = $settings;
         $this->events = $events;
         $this->extensionManager = $extensionManager;
         $this->logger = $logger;
+        $this->database = $database;
     }
 
     public function __invoke(ShowDiscussionController $controller, Discussion $discussion, ServerRequestInterface $request, $document)
@@ -60,8 +64,9 @@ class AddDiscussionViewHandler
         $clientIp = Arr::get($request->getServerParams(), 'HTTP_CLIENT_IP') ??
             Arr::get($request->getServerParams(), 'HTTP_X_FORWARDED_FOR') ??
             Arr::get($request->getServerParams(), 'REMOTE_ADDR');
+        $trackUnique = $this->settings->get('michaelbelgium-discussionviews.track_unique', false);
 
-        if($this->settings->get('michaelbelgium-discussionviews.track_unique', false))
+        if($trackUnique)
         {
             if($clientIp === null)
             {
@@ -69,30 +74,55 @@ class AddDiscussionViewHandler
                 return;
             }
 
-            $existingViews = $discussion->views()->where('ip', $clientIp)->get();
-            if($existingViews->count() > 0) {
+            if ($discussion->views()->where('ip', $clientIp)->exists()) {
                 return;
             }
         }
-        
-        $view = new DiscussionView();
-        
-        if(!$request->getAttribute('actor')->isGuest()) {
-            $view->user()->associate($request->getAttribute('actor'));
-        } elseif(!$this->settings->get('michaelbelgium-discussionviews.track_guests', true)) {
+
+        $actor = $request->getAttribute('actor');
+
+        if ($actor->isGuest() && !$this->settings->get('michaelbelgium-discussionviews.track_guests', true)) {
             return;
         }
 
-        $view->discussion()->associate($discussion);
-        $view->ip = $clientIp;
-        $view->visited_at = Carbon::now();
+        $recorded = $this->database->transaction(function () use ($actor, $clientIp, $discussion, $trackUnique) {
+            $this->database->table('discussions')
+                ->where('id', $discussion->id)
+                ->lockForUpdate()
+                ->first();
 
-        $discussion->views()->save($view);
+            if ($trackUnique) {
+                $inserted = $this->database->table('discussion_view_uniques')->insertOrIgnore([
+                    'discussion_id' => $discussion->id,
+                    'ip' => $clientIp,
+                ]);
 
-        //for the (un)popular filter
-        $discussion->increment('view_count');
-        $discussion->save();
+                // A row already present means this IP was seen before and may have been archived.
+                if ($inserted === 0) {
+                    return false;
+                }
+            }
 
-        $this->events->dispatch(new DiscussionWasViewed($request->getAttribute('actor'), $discussion));
+            $view = new DiscussionView();
+
+            if (!$actor->isGuest()) {
+                $view->user()->associate($actor);
+            }
+
+            $view->discussion()->associate($discussion);
+            $view->ip = $clientIp;
+            $view->visited_at = Carbon::now();
+
+            $discussion->views()->save($view);
+            $discussion->increment('view_count');
+
+            return true;
+        });
+
+        if (!$recorded) {
+            return;
+        }
+
+        $this->events->dispatch(new DiscussionWasViewed($actor, $discussion));
     }
 }

--- a/src/Listeners/AddDiscussionViewHandler.php
+++ b/src/Listeners/AddDiscussionViewHandler.php
@@ -52,7 +52,7 @@ class AddDiscussionViewHandler
             $bySlug = Arr::get($request->getQueryParams(), 'bySlug', false);
 
             if (!$bySlug) {
-                $this->logger->info(__CLASS__ . ': Not counting view to discussion '. $discussion->id .' because it wasn\'t a manual visit to the discussion page');
+                // $this->logger->info(__CLASS__ . ': Not counting view to discussion '. $discussion->id .' because it wasn\'t a manual visit to the discussion page');
                 return;
             }
         }
@@ -65,7 +65,7 @@ class AddDiscussionViewHandler
         {
             if($clientIp === null)
             {
-                $this->logger->warning(__CLASS__ . ': Unable to get client IP => not counting this view for discussion '. $discussion->id .'.');
+                // $this->logger->warning(__CLASS__ . ': Unable to get client IP => not counting this view for discussion '. $discussion->id .'.');
                 return;
             }
 

--- a/src/Listeners/MergeDiscussionHandler.php
+++ b/src/Listeners/MergeDiscussionHandler.php
@@ -3,20 +3,87 @@
 namespace Michaelbelgium\Discussionviews\Listeners;
 
 
-use Flarum\Discussion\Discussion;
 use FoF\MergeDiscussions\Events\MergingDiscussions;
+use Illuminate\Database\ConnectionInterface;
 
 class MergeDiscussionHandler
 {
+    private ConnectionInterface $database;
+
+    public function __construct(ConnectionInterface $database)
+    {
+        $this->database = $database;
+    }
+
     public function handle(MergingDiscussions $event)
     {
         $targetDiscussion = $event->discussion;
+        $mergedIds = $event->mergedDiscussions
+            ->pluck('id')
+            ->reject(function ($id) use ($targetDiscussion) {
+                return (int) $id === (int) $targetDiscussion->id;
+            })
+            ->values()
+            ->all();
 
-        $targetDiscussion->increment('view_count', $event->mergedDiscussions->sum('view_count'));
-        $targetDiscussion->save();
+        if (empty($mergedIds)) {
+            return;
+        }
 
-        $event->mergedDiscussions->each(function(Discussion $discussion) use ($targetDiscussion) {
-            $discussion->views()->update(['discussion_id' => $targetDiscussion->id]);
+        $this->database->transaction(function () use ($event, $mergedIds, $targetDiscussion) {
+            $discussionIds = array_merge([$targetDiscussion->id], $mergedIds);
+            $archiveRows = array_map(function ($discussionId) {
+                return [
+                    'discussion_id' => $discussionId,
+                    'archived_view_count' => 0,
+                ];
+            }, $discussionIds);
+
+            $this->database->table('discussion_view_archives')->insertOrIgnore($archiveRows);
+            $this->database->table('discussion_view_archives')
+                ->whereIn('discussion_id', $discussionIds)
+                ->orderBy('discussion_id')
+                ->lockForUpdate()
+                ->get();
+            $this->database->table('discussions')
+                ->whereIn('id', $discussionIds)
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
+
+            $targetDiscussion->increment('view_count', $event->mergedDiscussions->sum('view_count'));
+
+            $this->database->table('discussion_views')
+                ->whereIn('discussion_id', $mergedIds)
+                ->update(['discussion_id' => $targetDiscussion->id]);
+
+            $archivedCount = $this->database->table('discussion_view_archives')
+                ->whereIn('discussion_id', $mergedIds)
+                ->sum('archived_view_count');
+
+            if ($archivedCount > 0) {
+                $this->database->table('discussion_view_archives')
+                    ->where('discussion_id', $targetDiscussion->id)
+                    ->increment('archived_view_count', $archivedCount);
+            }
+
+            $this->database->table('discussion_view_uniques')
+                ->whereIn('discussion_id', $mergedIds)
+                ->orderBy('discussion_id')
+                ->orderBy('ip')
+                ->chunk(1000, function ($uniques) use ($targetDiscussion) {
+                    $rows = $uniques->map(function ($unique) use ($targetDiscussion) {
+                        return [
+                            'discussion_id' => $targetDiscussion->id,
+                            'ip' => $unique->ip,
+                        ];
+                    })->all();
+
+                    $this->database->table('discussion_view_uniques')->insertOrIgnore($rows);
+                });
+
+            $this->database->table('discussion_view_uniques')->whereIn('discussion_id', $mergedIds)->delete();
+            $this->database->table('discussion_view_archives')->whereIn('discussion_id', $mergedIds)->delete();
         });
     }
 }

--- a/src/Listeners/SaveDiscussionFromModal.php
+++ b/src/Listeners/SaveDiscussionFromModal.php
@@ -2,20 +2,44 @@
 namespace Michaelbelgium\Discussionviews\Listeners;
 
 use Flarum\Discussion\Event\Saving;
+use Illuminate\Database\ConnectionInterface;
 
 class SaveDiscussionFromModal
 {
+	private ConnectionInterface $database;
+
+	public function __construct(ConnectionInterface $database)
+	{
+		$this->database = $database;
+	}
+
 	public function handle(Saving $event)
 	{
 		if(isset($event->data["attributes"]["resetViews"]) && $event->data["attributes"]["resetViews"] === true)
 		{
 			$discussion = $event->discussion;
 
-			$discussion->views()->delete();
+			$this->database->transaction(function () use ($discussion) {
+				$this->database->table('discussion_view_archives')->insertOrIgnore([
+					'discussion_id' => $discussion->id,
+					'archived_view_count' => 0,
+				]);
+				$this->database->table('discussion_view_archives')
+					->where('discussion_id', $discussion->id)
+					->lockForUpdate()
+					->first();
+				$this->database->table('discussions')
+					->where('id', $discussion->id)
+					->lockForUpdate()
+					->first();
 
-			//for the (un)popular filter
-			$discussion->view_count = 0;
-			$discussion->save();
+				$this->database->table('discussion_view_uniques')->where('discussion_id', $discussion->id)->delete();
+				$discussion->views()->delete();
+				$this->database->table('discussion_view_archives')->where('discussion_id', $discussion->id)->delete();
+
+				$discussion->view_count = 0;
+				$discussion->save();
+			});
 		}
 	}
 }


### PR DESCRIPTION
The original approach of this extension is not well-optimized enough for massive forums. A single query for last several viewers could consume more than 1 second for a discussion with ~500k views, causing ~2s overall delay each time loading.

I made this PR mainly to solve this issue through database optimizations.
- Added table `discussion_view_archives` to archive stale visits into single integer
- Added table `discussion_view_uniques` to implement unique visitors
- Added scheduled task (or manually execute through `php flarum discussion-views:archive`) to trim and archive visits beyond 1000 for each discussion. By default runs every 10 minutes with Flarum's scheduler.
- Removed unuseful logger which fills log with almost meaningless information.
- Minor tweak on the frontend to ensure visitors widget always at the bottom.

These measures saves >1.5s each time loading for some popular posts in my case. Please consider merging since afaik many huge forums use this extension.